### PR TITLE
Add Docker support for project setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.pytest_cache/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.log
+*.env
+*.venv
+.env*
+.DS_Store
+.vscode/
+tests/
+Dockerfile
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS builder
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+ENV UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /pbcm
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+COPY . /pbcm
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+FROM python:3.13-slim-trixie
+
+RUN groupadd --system --gid 999 nonroot \
+ && useradd --system --gid 999 --uid 999 --create-home nonroot
+
+COPY --from=builder --chown=nonroot:nonroot /pbcm /pbcm
+
+ENV PATH="/pbcm/.venv/bin:$PATH"
+
+USER nonroot
+
+WORKDIR /pbcm
+
+CMD ["fastapi", "run", "--host", "0.0.0.0", "app/main.py"]


### PR DESCRIPTION
Introduce a Dockerfile and .dockerignore to streamline the project setup and ensure proper production environment configuration.